### PR TITLE
Expose default LLM settings

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -95,3 +95,15 @@ SVR_HTTP_PORT=9380
 REGISTER_ENABLED=0
 RAGFLOW_ADMIN_EMAIL=admin@ragflow.io
 RAGFLOW_ADMIN_PASSWORD=changeme
+
+############################
+# LLM defaults
+############################
+LLM_FACTORY=OpenAI
+LLM_API_KEY=
+LLM_API_BASE=
+LLM_CHAT_MODEL=gpt-3.5-turbo
+LLM_EMBEDDING_MODEL=text-embedding-ada-002
+LLM_RERANK_MODEL=
+LLM_ASR_MODEL=
+LLM_IMAGE2TEXT_MODEL=

--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ default tenant. Visit `https://ragflow.${TRAEFIK_DOMAIN}` to access the UI.
 Tune registration behaviour or credentials in `.env` or the corresponding
 Ansible defaults. RAGFlow talks to MySQL, MinIO and Valkey using the variables in
 the env‑file (`MINIO_USER`, `MINIO_PASSWORD`, `REDIS_HOST`, …).
+
+The default language model backend is controlled via the `user_default_llm`
+block in `service_conf.yaml`. Override values such as `LLM_FACTORY`,
+`LLM_API_KEY` or `LLM_CHAT_MODEL` in your `.env` to point RAGFlow at a
+different provider or model.
 ---
 
 ## After cloning – quick checklist

--- a/ansible/roles/pocket_lab/defaults/main.yaml.template
+++ b/ansible/roles/pocket_lab/defaults/main.yaml.template
@@ -93,6 +93,15 @@ register_enabled: 0
 ragflow_admin_email: "admin@ragflow.io"
 ragflow_admin_password: "changeme"
 
+llm_factory: "OpenAI"
+llm_api_key: ""
+llm_api_base: ""
+llm_chat_model: "gpt-3.5-turbo"
+llm_embedding_model: "text-embedding-ada-002"
+llm_rerank_model: ""
+llm_asr_model: ""
+llm_image2text_model: ""
+
 # ---------- Twingate ----------
 tg_tenant_name: "your-tenant"
 tg_container_name1: "tg-connector-1"

--- a/ansible/roles/pocket_lab/files/ragflow/service_conf.yaml.template
+++ b/ansible/roles/pocket_lab/files/ragflow/service_conf.yaml.template
@@ -64,16 +64,16 @@ redis:
 #   secret: 'secret'
 #   tenant_id: 'tenant_id'
 #   container_name: 'container_name'
-# user_default_llm:
-#   factory: 'Tongyi-Qianwen'
-#   api_key: 'sk-xxxxxxxxxxxxx'
-#   base_url: ''
-#   default_models:
-#     chat_model: 'qwen-plus'
-#     embedding_model: 'BAAI/bge-large-zh-v1.5@BAAI'
-#     rerank_model: ''
-#     asr_model: ''
-#     image2text_model: ''
+user_default_llm:
+  factory: '${LLM_FACTORY:-OpenAI}'
+  api_key: '${LLM_API_KEY:-}'
+  base_url: '${LLM_API_BASE:-}'
+  default_models:
+    chat_model: '${LLM_CHAT_MODEL:-gpt-3.5-turbo}'
+    embedding_model: '${LLM_EMBEDDING_MODEL:-text-embedding-ada-002}'
+    rerank_model: '${LLM_RERANK_MODEL:-}'
+    asr_model: '${LLM_ASR_MODEL:-}'
+    image2text_model: '${LLM_IMAGE2TEXT_MODEL:-}'
 # oauth:
 #   oauth2:
 #     display_name: "OAuth2"

--- a/ansible/roles/pocket_lab/templates/.env.j2
+++ b/ansible/roles/pocket_lab/templates/.env.j2
@@ -99,6 +99,16 @@ REGISTER_ENABLED={{ register_enabled }}
 RAGFLOW_ADMIN_EMAIL={{ ragflow_admin_email }}
 RAGFLOW_ADMIN_PASSWORD={{ ragflow_admin_password }}
 
+# ───────── LLM defaults ────────────────────────────────────────────────
+LLM_FACTORY={{ llm_factory | default('OpenAI') }}
+LLM_API_KEY={{ llm_api_key | default('') }}
+LLM_API_BASE={{ llm_api_base | default('') }}
+LLM_CHAT_MODEL={{ llm_chat_model | default('gpt-3.5-turbo') }}
+LLM_EMBEDDING_MODEL={{ llm_embedding_model | default('text-embedding-ada-002') }}
+LLM_RERANK_MODEL={{ llm_rerank_model | default('') }}
+LLM_ASR_MODEL={{ llm_asr_model | default('') }}
+LLM_IMAGE2TEXT_MODEL={{ llm_image2text_model | default('') }}
+
 # ───────── Twingate ─────────────────────────────────────────────────
 TG_TENANT_NAME={{ tg_tenant_name }}
 TG_CONNECTOR_VERSION={{ tg_connector_version | default('1.68.0') }}


### PR DESCRIPTION
## Summary
- enable `user_default_llm` in `service_conf.yaml.template`
- expose LLM variables in `.env.template`
- template LLM options in the Ansible role and defaults
- document how to configure the default LLM in RAGFlow

## Testing
- `task --list` *(fails: command not found)*
