### PR TITLE
Update AGENTS notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@ This repository contains Ansible playbooks and Docker Compose files. When
 modifying files keep the following in mind:
 
 - Use two spaces for YAML indentation and keep the existing formatting.
+- Keep variable files with their block‑comment style so sections stay
+  clearly separated.
 - Update `README.md` whenever behaviour or variables change.
 - If you change Ansible or Compose files, try to run a syntax check:
   - `ansible-playbook --syntax-check ansible/site.yaml` (requires Ansible)

--- a/ansible/AGENTS.md
+++ b/ansible/AGENTS.md
@@ -3,3 +3,5 @@
 - YAML files use two space indentation and no document start markers.
 - Playbooks live in `ansible/plays/` and roles in `ansible/roles/`.
 - Keep variable names snake_case.
+- `.env.j2` and role defaults follow the same block-comment convention as
+  other variable files.


### PR DESCRIPTION
## Summary
- add note about block-comment style in root AGENTS
- mention `.env.j2` and defaults use that same style in Ansible docs

## Testing
- `ansible-playbook --syntax-check ansible/site.yaml` *(fails: role `l3d.users.user` missing)*
- `docker-compose -f ansible/roles/pocket_lab/files/compose.yaml config` *(fails: invalid expose fields)*

------
https://chatgpt.com/codex/tasks/task_e_6851dba290cc8324b394b76efed4c28d