### PR TITLE
Add docs for remaining services

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@
     - [Ollama 🦙](#ollama-)
     - [MinIO ☁️](#minio-️)
     - [Secure-access layer - Tailscale 🔐](#secure-access-layer---tailscale-)
+    - [MySQL 🐬](#mysql-)
+    - [Infinity ♾️](#infinity-)
+    - [Valkey (Redis drop-in) 🐏](#valkey-redis-drop-in-)
+    - [Elasticsearch 🔍](#elasticsearch-)
+    - [Portainer 🛠️](#portainer-)
+    - [Prometheus 📊](#prometheus-)
+    - [Grafana 📈](#grafana-)
+    - [Loki 📜](#loki-)
+    - [SMTP relay ✉️](#smtp-relay-)
     - [Typical workflows](#typical-workflows)
     - [Provisioning with Ansible](#provisioning-with-ansible)
       - [Task catalogue](#task-catalogue)
@@ -281,9 +290,10 @@ dashboard can reach the backend.
 Full variable reference lives in:
     
 - `ansible/roles/ensure_conn_user/defaults/main.yaml`
-   
+
 
 ---
+
 
 ### Secure-access layer - Tailscale 🔐
 
@@ -312,6 +322,80 @@ When the stack comes up the **tailscale** service automatically:
 * advertises the subnet defined by `DOCKER_BRIDGE_SUBNET`
 * enables Tailscale SSH on the host and every container (via `--ssh`)
 
+### MySQL 🐬
+
+RAGFlow stores its relational data in a standalone MySQL container. Set
+`MYSQL_ROOT_PASSWORD` for the root account and adjust `MYSQL_DATABASE`
+to change the default schema. `MYSQL_PORT` and `MYSQL_HOST` control the
+exposed port and container name.
+
+---
+
+### Infinity ♾️
+
+Infinity provides the vector index used by RAGFlow. The included
+`infinity_conf.toml` configures storage paths while the ports are
+customisable through `INFINITY_THRIFT_PORT`, `INFINITY_HTTP_PORT` and
+`INFINITY_PSQL_PORT`. The service registers under
+`INFINITY_HOST`.
+
+---
+
+### Valkey (Redis drop-in) 🐏
+
+Valkey offers a Redis-compatible key–value store. Protect it with
+`REDIS_PASSWORD` and change the image or port via `REDIS_VERSION` and
+`REDIS_PORT`.
+
+---
+
+### Elasticsearch 🔍
+
+Elasticsearch indexes all documents for RAGFlow. Modify
+`ES_PASSWORD` for the elastic user and `ES_PORT` for the HTTP API.
+`ES_HOST` chooses the hostname while `MEM_LIMIT` limits container
+memory usage.
+
+---
+
+### Portainer 🛠️
+
+Portainer exposes a small Docker dashboard at
+`https://portainer.${TRAEFIK_DOMAIN}` protected by Traefik basic-auth.
+Update `PORTAINER_VERSION` or change the UI port with `PORTAINER_PORT`.
+
+---
+
+### Prometheus 📊
+
+Prometheus collects metrics from node-exporter and the stack. The image
+tag is set via `PROMETHEUS_VERSION`. Additional scrape targets can be
+defined in `prometheus/prometheus.yaml`.
+
+---
+
+### Grafana 📈
+
+Grafana visualises metrics at `https://grafana.${TRAEFIK_DOMAIN}`.
+Initial credentials come from `GRAFANA_ADMIN_USER` and
+`GRAFANA_ADMIN_PASSWORD`. Use `GRAFANA_VERSION` to upgrade.
+
+---
+
+### Loki 📜
+
+Loki stores container logs that Grafana can query. Change
+`LOKI_VERSION` if you need a different release.
+
+---
+
+### SMTP relay ✉️
+
+A lightweight Postfix relay lets services send mail. Set `SMTP_IMAGE`
+to choose the container, `SMTP_PORT` for the listening port and
+`SMTP_SSL` to toggle TLS. The hostname is derived from `SMTP_HOST`.
+
+---
 ### Typical workflows
 ```bash
 # list all lab containers – works from any device in the tailnet
@@ -386,6 +470,80 @@ The individual phases live in `ansible/plays/00-30-*.yaml` and can be run via
 
 | Variable                             |  Default             value                                           |  Service      |                                           Description                                       |                       Comments                                 |
 | ------------------------------------ | -------------------------------------------------------------------- | ------------- | ------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+### MySQL 🐬
+
+RAGFlow stores its relational data in a standalone MySQL container. Set
+`MYSQL_ROOT_PASSWORD` for the root account and adjust `MYSQL_DATABASE`
+to change the default schema. `MYSQL_PORT` and `MYSQL_HOST` control the
+exposed port and container name.
+
+---
+
+### Infinity ♾️
+
+Infinity provides the vector index used by RAGFlow. The included
+`infinity_conf.toml` configures storage paths while the ports are
+customisable through `INFINITY_THRIFT_PORT`, `INFINITY_HTTP_PORT` and
+`INFINITY_PSQL_PORT`. The service registers under
+`INFINITY_HOST`.
+
+---
+
+### Valkey (Redis drop-in) 🐏
+
+Valkey offers a Redis-compatible key–value store. Protect it with
+`REDIS_PASSWORD` and change the image or port via `REDIS_VERSION` and
+`REDIS_PORT`.
+
+---
+
+### Elasticsearch 🔍
+
+Elasticsearch indexes all documents for RAGFlow. Modify
+`ES_PASSWORD` for the elastic user and `ES_PORT` for the HTTP API.
+`ES_HOST` chooses the hostname while `MEM_LIMIT` limits container
+memory usage.
+
+---
+
+### Portainer 🛠️
+
+Portainer exposes a small Docker dashboard at
+`https://portainer.${TRAEFIK_DOMAIN}` protected by Traefik basic-auth.
+Update `PORTAINER_VERSION` or change the UI port with `PORTAINER_PORT`.
+
+---
+
+### Prometheus 📊
+
+Prometheus collects metrics from node-exporter and the stack. The image
+tag is set via `PROMETHEUS_VERSION`. Additional scrape targets can be
+defined in `prometheus/prometheus.yaml`.
+
+---
+
+### Grafana 📈
+
+Grafana visualises metrics at `https://grafana.${TRAEFIK_DOMAIN}`.
+Initial credentials come from `GRAFANA_ADMIN_USER` and
+`GRAFANA_ADMIN_PASSWORD`. Use `GRAFANA_VERSION` to upgrade.
+
+---
+
+### Loki 📜
+
+Loki stores container logs that Grafana can query. Change
+`LOKI_VERSION` if you need a different release.
+
+---
+
+### SMTP relay ✉️
+
+A lightweight Postfix relay lets services send mail. Set `SMTP_IMAGE`
+to choose the container, `SMTP_PORT` for the listening port and
+`SMTP_SSL` to toggle TLS. The hostname is derived from `SMTP_HOST`.
+
+---
 | `TRAEFIK_BASIC_AUTH`                 | `admin:$2y$12$Kz0IUpZjbNkS7N0S2E5qe <br>OeJ8V4aH.E4W2KIiMzFxLpy0X58F3Riq` | Traefik       | htpasswd‑style `user:hash`.  Demo credentials = **admin / admin** – replace for production. | user\:hash used by Traefik basic-auth middleware for most UIs. |
 | `TRAEFIK_DOMAIN`                     | `ai.lab.example.com`                                                 | Traefik       | Apex domain under which all sub‑services are published.                                     |                                                                |
 | `TRAEFIK_LE_EMAIL`                   | `admin@example.com`                                                  | Traefik       | Contact e‑mail for Let’s Encrypt.                                                           |                                                                |


### PR DESCRIPTION
## Summary
- document MySQL, Infinity, Valkey, Elasticsearch and observability services
- explain Portainer and SMTP relay configuration
- update README table of contents
- place new sections after the Tailscale docs

## Testing
- `ansible-playbook --syntax-check ansible/site.yaml` *(fails: role 'l3d.users.user' not found)*
- `docker compose -f ansible/roles/pocket_lab/files/compose.yaml config` *(fails: 'docker compose' not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6881faa0d02c83249dd968fb3639abed