### PR TITLE
Add first-party web search via SearXNG and wire Open WebUI to Ollama + SearXNG (privacy-first defaults)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -78,13 +78,20 @@ OPENWEBUI_ADMIN_PASSWORD=changeme
 OPENWEBUI_ENABLE_PERSISTENT_CONFIG=true
 OPENWEBUI_ENABLE_SIGNUP=false
 OPENWEBUI_DEFAULT_USER_ROLE=pending
-OFFLINE_MODE=true
+WEBUI_URL=
+OFFLINE_MODE=false
 ENABLE_VERSION_UPDATE_CHECK=false
-WEBUI_URL=https://chat.${TRAEFIK_DOMAIN}
+OLLAMA_BASE_URL=http://ollama:11434
+
+############################
+# OPENWEBUI WEB SEARCH
+############################
 ENABLE_WEB_SEARCH=true
-WEB_SEARCH_ENGINE=duckduckgo
-WEB_SEARCH_RESULT_COUNT=3
-WEB_SEARCH_CONCURRENT_REQUESTS=8
+WEB_SEARCH_ENGINE=searxng
+ENABLE_SEARCH_QUERY_GENERATION=false
+WEB_SEARCH_RESULT_COUNT=5
+WEB_SEARCH_CONCURRENT_REQUESTS=2
+SEARXNG_QUERY_URL=http://searxng:8080/search?q=<query>&format=json
 DEFAULT_MODELS=llama3.1:8b
 DEFAULT_PROMPT_SUGGESTIONS=[{"title":"Code review","content":"Review the following code and point out bugs, security issues, and style problems."},{"title":"Explain a snippet","content":"Explain what this code does and how to improve it."},{"title":"Research topic","content":"Summarize recent developments on <topic> with citations and links."},{"title":"Write tests","content":"Generate unit tests for this function with edge cases."}]
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Everything – from reverse‑proxy, observability, vector and relational stores
     - [Grafana 📈](#grafana-)
     - [Loki 📜](#loki-)
     - [SMTP relay ✉️](#smtp-relay-️)
+    - [Web search (Open WebUI + SearXNG) 🔎](#web-search-open-webui--searxng-)
     - [Typical workflows](#typical-workflows)
     - [Provisioning with Ansible](#provisioning-with-ansible)
       - [Task catalogue](#task-catalogue)
@@ -390,6 +391,31 @@ Loki stores container logs that Grafana can query. Change
 A lightweight Postfix relay lets services send mail. Set `SMTP_IMAGE`
 to choose the container, `SMTP_PORT` for the listening port and
 `SMTP_SSL` to toggle TLS. The hostname is derived from `SMTP_HOST`.
+
+---
+### Web search (Open WebUI + SearXNG) 🔎
+
+Pocket-Lab ships a private [SearXNG](https://docs.searxng.org) instance (internal-only) and wires it into **Open WebUI** as the default web search backend. JSON output is enabled and rate limiting is disabled for private use.
+
+**Defaults (override in `.env` / Ansible vars):**
+
+```env
+# endpoints & privacy
+WEBUI_URL=https://chat.<your-domain>
+OFFLINE_MODE=false
+ENABLE_VERSION_UPDATE_CHECK=false
+OLLAMA_BASE_URL=http://ollama:11434
+
+# web search
+ENABLE_WEB_SEARCH=true
+WEB_SEARCH_ENGINE=searxng
+SEARXNG_QUERY_URL=http://searxng:8080/search?q=<query>&format=json
+WEB_SEARCH_RESULT_COUNT=5
+WEB_SEARCH_CONCURRENT_REQUESTS=2
+ENABLE_SEARCH_QUERY_GENERATION=false
+```
+
+> Why SearXNG? It avoids public-instance rate limits and API blocks while keeping search local to your stack. Open WebUI discovers it through `WEB_SEARCH_ENGINE=searxng` + `SEARXNG_QUERY_URL`. See Open WebUI env config & tutorial. Also ensure SearXNG exposes JSON (`search.formats: [html, json]`). :contentReference[oaicite:2]{index=2}
 
 ---
 ### Typical workflows

--- a/ansible/roles/pocket_lab/defaults/main.yaml
+++ b/ansible/roles/pocket_lab/defaults/main.yaml
@@ -61,19 +61,24 @@ openwebui_admin_password: "changeme"
 openwebui_enable_signup: false
 openwebui_default_user_role: "pending"
 openwebui_enable_persistent_config: true
-openwebui_offline_mode: true
+# ---------- openwebui: endpoints & web search ----------
+# Derived URL used by Open WebUI for building absolute links (set in template)
+webui_url: ""
+openwebui_offline_mode: false
 openwebui_enable_version_update_check: false
 openwebui_enable_web_search: true
-openwebui_web_search_engine: "duckduckgo"
-openwebui_web_search_result_count: 3
-openwebui_web_search_concurrent_requests: 8
+openwebui_web_search_engine: "searxng"
+openwebui_enable_search_query_generation: false
+openwebui_web_search_result_count: 5
+openwebui_web_search_concurrent_requests: 2
+searxng_query_url: "http://searxng:8080/search?q=<query>&format=json"
+ollama_base_url: "http://ollama:11434"
 openwebui_default_models: "llama3.1:8b deepseek-r1:7b qwen2.5-coder:7b"
 openwebui_default_prompt_suggestions:
   - { title: "Code review",        content: "Review the following code and point out bugs, security issues, and style problems." }
   - { title: "Explain a snippet",  content: "Explain what this code does and how to improve it." }
   - { title: "Research topic",     content: "Summarize recent developments on <topic> with citations and links." }
   - { title: "Write tests",        content: "Generate unit tests for this function with edge cases." }
-ollama_base_url: "http://ollama:11434"
 
 
 # ----------  Elasticsearch ----------

--- a/ansible/roles/pocket_lab/files/compose.yaml
+++ b/ansible/roles/pocket_lab/files/compose.yaml
@@ -268,6 +268,18 @@ services:
     - traefik.http.services.openwebui.loadbalancer.server.port=${OPENWEBUI_PORT}
     - traefik.http.services.openwebui.loadbalancer.server.scheme=http
 
+  # --------------------------- WEB SEARCH ---------------------------
+  searxng:
+    <<: *common
+    image: searxng/searxng:latest
+    container_name: searxng
+    expose:
+      - "8080"
+    volumes:
+      - ./searxng/settings.yml:/etc/searxng/settings.yml:ro
+    # intentionally no Traefik labels: internal use only
+    networks: [ backend ]
+
   ############################
   #     DATA / RAG STACK     #
   ############################

--- a/ansible/roles/pocket_lab/files/searxng/settings.yml
+++ b/ansible/roles/pocket_lab/files/searxng/settings.yml
@@ -1,0 +1,10 @@
+use_default_settings: true
+server:
+  bind_address: 0.0.0.0
+  secret_key: "change-me"
+  public_instance: false
+  # Private, first-party use: disable rate limiting & bot detection
+  limiter: false
+search:
+  # Ensure JSON API responses are available
+  formats: [html, json]

--- a/ansible/roles/pocket_lab/templates/.env.j2
+++ b/ansible/roles/pocket_lab/templates/.env.j2
@@ -62,16 +62,21 @@ OPENWEBUI_ADMIN_PASSWORD={{ openwebui_admin_password | default('changeme') }}
 OPENWEBUI_ENABLE_SIGNUP={{ openwebui_enable_signup | default(false) | lower }}
 OPENWEBUI_DEFAULT_USER_ROLE={{ openwebui_default_user_role | default('pending') }}
 OPENWEBUI_ENABLE_PERSISTENT_CONFIG={{ openwebui_enable_persistent_config | default(true) | lower }}
-OFFLINE_MODE={{ openwebui_offline_mode | default(true) | lower }}
-ENABLE_VERSION_UPDATE_CHECK={{ openwebui_enable_version_update_check | default(false) | lower }}
-WEBUI_URL=https://chat.{{ stack_domain }}
-ENABLE_WEB_SEARCH={{ openwebui_enable_web_search | default(true) | lower }}
-WEB_SEARCH_ENGINE={{ openwebui_web_search_engine | default('duckduckgo') }}
-WEB_SEARCH_RESULT_COUNT={{ openwebui_web_search_result_count | default(3) }}
-WEB_SEARCH_CONCURRENT_REQUESTS={{ openwebui_web_search_concurrent_requests | default(8) }}
+# --- Open WebUI runtime / privacy / endpoints ---
+WEBUI_URL={{ webui_url | default('https://chat.' ~ stack_domain) }}
+OFFLINE_MODE={{ openwebui_offline_mode | lower }}
+ENABLE_VERSION_UPDATE_CHECK={{ openwebui_enable_version_update_check | lower }}
+OLLAMA_BASE_URL={{ ollama_base_url }}
+
+# --- Web search wiring (SearXNG by default, private / internal) ---
+ENABLE_WEB_SEARCH={{ openwebui_enable_web_search | lower }}
+WEB_SEARCH_ENGINE={{ openwebui_web_search_engine }}
+ENABLE_SEARCH_QUERY_GENERATION={{ openwebui_enable_search_query_generation | lower }}
+WEB_SEARCH_RESULT_COUNT={{ openwebui_web_search_result_count }}
+WEB_SEARCH_CONCURRENT_REQUESTS={{ openwebui_web_search_concurrent_requests }}
+SEARXNG_QUERY_URL={{ searxng_query_url }}
 DEFAULT_MODELS={{ openwebui_default_models | default('llama3.1:8b') }}
 DEFAULT_PROMPT_SUGGESTIONS='{{ openwebui_default_prompt_suggestions | to_json }}'
-OLLAMA_BASE_URL={{ ollama_base_url | default('http://ollama:11434') }}
 
 # ───────── Elasticsearch  ───────────────────
 ES_VERSION={{ es_version | default('8.13.4') }}


### PR DESCRIPTION
## Summary
- add internal SearXNG service and wire Open WebUI web-search to it
- expose Ollama and web-search env settings through Ansible defaults, templates and `.env` samples
- document private SearXNG integration and privacy-focused defaults

## Testing
- `ansible-playbook --syntax-check ansible/site.yaml` *(fails: role 'geerlingguy.docker' not found)*
- `docker compose -f ansible/roles/pocket_lab/files/compose.yaml config` *(fails: variable warnings and invalid volume spec)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a23fca088324b3f032a882c9cdfc